### PR TITLE
Add link to running on run.dlang.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # automem
 
 [![Build Status](https://travis-ci.org/atilaneves/automem.png?branch=master)](https://travis-ci.org/atilaneves/automem)
+[![Open on run.dlang.io](https://img.shields.io/badge/run.dlang.io-open-blue.svg)](https://run.dlang.io/is/hZE7IT)
 
 C++-style automatic memory management smart pointers for D using `std.experimental.allocator`.
 


### PR DESCRIPTION
I thought it would be nice for people to play around with a `@nogc` library.

https://run.dlang.io/is/hZE7IT

The badge is just an idea.
If you want, you can also add yourself to the DUB series - e.g. https://tour.dlang.org/tour/en/dub/mir

FYI: the libraries on run.dlang.io are updated daily and use the latest tag.