### PR TITLE
Bump-up test_allocator dub version to 0.2.0

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -18,7 +18,7 @@
             "excludedSourceFiles": ["src/main.d"],
             "dependencies": {
                 "unit-threaded": "~>0.7.0",
-                "test_allocator": "~>0.1.0"
+                "test_allocator": "~>0.2.0"
             }
         },
         {
@@ -29,7 +29,7 @@
             "excludedSourceFiles": ["src/main.d"],
             "dependencies": {
                 "unit-threaded": "~>0.7.0",
-                "test_allocator": "~>0.1.0"
+                "test_allocator": "~>0.2.0"
             },
             "versions": ["unitThreadedLight"]
         }

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,7 +1,8 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"test_allocator": "0.1.0",
+		"stdx-allocator": "2.77.1",
+		"test_allocator": "0.2.0",
 		"unit-threaded": "0.7.43"
 	}
 }


### PR DESCRIPTION
>Following up the `TestAllocator` [PR](https://github.com/atilaneves/test_allocator/pull/1), this is updating the dub version for the test_allocator package to `0.1.1`

Following up this `TestAllocator` [PR](https://github.com/atilaneves/test_allocator/pull/2), this is updating the dub version for the test_allocator package to `0.2.0`
I'm guessing this is the next step in unblocking this `Phobos` [PR](https://github.com/dlang/phobos/pull/6444)

Cheers,
Eduard