### PR TITLE
Use dub stdx-allocator package to avoid future breakages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage](https://codecov.io/gh/atilaneves/automem/branch/master/graph/badge.svg)](https://codecov.io/gh/atilaneves/automem)
 [![Open on run.dlang.io](https://img.shields.io/badge/run.dlang.io-open-blue.svg)](https://run.dlang.io/is/P3yCpG)
 
-C++-style automatic memory management smart pointers for D using `std.experimental.allocator`.
+C++-style automatic memory management smart pointers for D using `stdx.allocator`.
 
 Unlike the C++ variants, the smart pointers themselves allocate the memory for the objects they contain.
 That ensures the right allocator is used to dispose of the memory as well.
@@ -29,7 +29,7 @@ Sample code:
 // can be @safe if the allocator has @safe functions
 @system @nogc unittest {
 
-    import std.experimental.allocator.mallocator: Mallocator;
+    import stdx.allocator.mallocator: Mallocator;
     import std.algorithm: move;
 
     struct Point {

--- a/dub.json
+++ b/dub.json
@@ -9,7 +9,12 @@
     "targetType": "library",
     "configurations": [
 
-        { "name": "library" },
+        {
+            "name": "library",
+            "dependencies": {
+                "stdx-allocator": "~>2.77.0"
+            }
+        },
         {
             "name": "unittest",
             "targetType": "executable",
@@ -18,7 +23,8 @@
             "excludedSourceFiles": ["src/main.d"],
             "dependencies": {
                 "unit-threaded": "~>0.7.0",
-                "test_allocator": "~>0.2.0"
+                "test_allocator": "~>0.2.0",
+                "stdx-allocator": "~>2.77.0"
             }
         },
         {
@@ -29,7 +35,8 @@
             "excludedSourceFiles": ["src/main.d"],
             "dependencies": {
                 "unit-threaded": "~>0.7.0",
-                "test_allocator": "~>0.2.0"
+                "test_allocator": "~>0.2.0",
+                "stdx-allocator": "~>2.77.0"
             },
             "versions": ["unitThreadedLight"]
         }

--- a/source/automem/allocator.d
+++ b/source/automem/allocator.d
@@ -1,5 +1,5 @@
 /**
-   Custom versions of std.experimental.allocator functions (unfortunately)
+   Custom versions of stdx.allocator functions (unfortunately)
  */
 module automem.allocator;
 
@@ -68,7 +68,7 @@ void dispose(A, T)(auto ref A alloc, T[] array)
 @system unittest
 {
 
-    import std.experimental.allocator: theAllocator, make, makeArray;
+    import stdx.allocator: theAllocator, make, makeArray;
 
     static int x;
     static interface I
@@ -109,8 +109,8 @@ void dispose(A, T)(auto ref A alloc, T[] array)
 ///
 @system unittest //bugzilla 15721
 {
-    import std.experimental.allocator: make;
-    import std.experimental.allocator.mallocator : Mallocator;
+    import stdx.allocator: make;
+    import stdx.allocator.mallocator : Mallocator;
 
     interface Foo {}
     class Bar: Foo {}

--- a/source/automem/package.d
+++ b/source/automem/package.d
@@ -1,5 +1,5 @@
 /**
-C++-style automatic memory management smart pointers for D using `std.experimental.allocator`.
+C++-style automatic memory management smart pointers for D using `stdx.allocator`.
 
 Unlike the C++ variants, the smart pointers themselves allocate the memory for the objects they contain.
 That ensures the right allocator is used to dispose of the memory as well.
@@ -33,7 +33,7 @@ mixin TestUtils;
 */
 @system @nogc unittest {
 
-    import std.experimental.allocator.mallocator: Mallocator;
+    import stdx.allocator.mallocator: Mallocator;
     import std.algorithm: move;
 
     struct Point {

--- a/source/automem/ref_counted.d
+++ b/source/automem/ref_counted.d
@@ -6,7 +6,7 @@ module automem.ref_counted;
 import automem.traits: isAllocator;
 import automem.test_utils: TestUtils;
 import automem.unique: Unique;
-import std.experimental.allocator: theAllocator, processAllocator;
+import stdx.allocator: theAllocator, processAllocator;
 import std.typecons: Flag;
 
 version(unittest) {
@@ -199,7 +199,7 @@ private:
     public ImplType* _impl; // public or alias this doesn't work
 
     void allocateImpl() {
-        import std.experimental.allocator: make;
+        import stdx.allocator: make;
         import std.traits: hasIndirections;
 
         _impl = cast(typeof(_impl))_allocator.allocate(Impl.sizeof);
@@ -362,7 +362,7 @@ private template makeObject(args...)
 
 @("struct test allocator one rvalue assignment mallocator")
 @system unittest {
-    import std.experimental.allocator.mallocator: Mallocator;
+    import stdx.allocator.mallocator: Mallocator;
     {
         RefCounted!(Struct, Mallocator) ptr;
         ptr = RefCounted!(Struct, Mallocator)(5);
@@ -513,7 +513,7 @@ static if (__VERSION__ >= 2079)
 
 @("assign from T")
 @system unittest {
-    import std.experimental.allocator.mallocator: Mallocator;
+    import stdx.allocator.mallocator: Mallocator;
 
     {
         auto a = RefCounted!(Struct, Mallocator)(3);
@@ -592,7 +592,7 @@ static if (__VERSION__ >= 2079) {
 
     @("threads Mallocator")
         @system unittest {
-        import std.experimental.allocator.mallocator: Mallocator;
+        import stdx.allocator.mallocator: Mallocator;
         static assert(__traits(compiles, sendRefCounted!Mallocator(7)));
     }
 

--- a/source/automem/test_utils.d
+++ b/source/automem/test_utils.d
@@ -11,13 +11,13 @@ mixin template TestUtils() {
          */
         auto theTestAllocator() {
             static struct Context {
-                import std.experimental.allocator: theAllocator;
+                import stdx.allocator: theAllocator;
 
                 TestAllocator testAllocator;
                 typeof(theAllocator) oldAllocator;
 
                 static auto create() {
-                    import std.experimental.allocator: allocatorObject;
+                    import stdx.allocator: allocatorObject;
 
                     Context ctx;
 
@@ -28,7 +28,7 @@ mixin template TestUtils() {
                 }
 
                 ~this() {
-                    import std.experimental.allocator: dispose;
+                    import stdx.allocator: dispose;
 
                     // 2.079.0 changed the API - we check here
                     static if(__traits(compiles, testAllocator.dispose(theAllocator)))
@@ -145,7 +145,7 @@ mixin template TestUtils() {
 
         private struct SafeAllocator {
 
-            import std.experimental.allocator.mallocator: Mallocator;
+            import stdx.allocator.mallocator: Mallocator;
 
             void[] allocate(this T)(size_t i) @trusted nothrow @nogc {
                 return Mallocator.instance.allocate(i);

--- a/source/automem/traits.d
+++ b/source/automem/traits.d
@@ -1,7 +1,7 @@
 module automem.traits;
 
 void checkAllocator(T)() {
-    import std.experimental.allocator: make, dispose;
+    import stdx.allocator: make, dispose;
     import std.traits: hasMember;
 
     static if(hasMember!(T, "instance"))
@@ -19,7 +19,7 @@ enum isAllocator(T) = is(typeof(checkAllocator!T));
 
 @("isAllocator")
 @safe @nogc pure unittest {
-    import std.experimental.allocator.mallocator: Mallocator;
+    import stdx.allocator.mallocator: Mallocator;
     import test_allocator: TestAllocator;
 
     static assert(isAllocator!Mallocator);

--- a/source/automem/unique.d
+++ b/source/automem/unique.d
@@ -5,7 +5,7 @@ module automem.unique;
 
 import automem.test_utils: TestUtils;
 import automem.traits: isAllocator;
-import std.experimental.allocator: theAllocator;
+import stdx.allocator: theAllocator;
 import std.typecons: Flag;
 
 version(unittest) {
@@ -184,7 +184,7 @@ private:
 private template makeObject(Flag!"supportGC" supportGC, args...)
 {
     void makeObject(Type,A)(ref Unique!(Type, A) u) {
-        import std.experimental.allocator: make;
+        import stdx.allocator: make;
         import std.functional : forward;
         import std.traits : hasIndirections;
         import core.memory : GC;
@@ -243,7 +243,7 @@ private template makeObject(Flag!"supportGC" supportGC, args...)
 @("with struct and mallocator")
 @system unittest {
 
-    import std.experimental.allocator.mallocator: Mallocator;
+    import stdx.allocator.mallocator: Mallocator;
     {
         const foo = Unique!(Struct, Mallocator)(5);
         foo.twice.shouldEqual(10);
@@ -350,7 +350,7 @@ private template makeObject(Flag!"supportGC" supportGC, args...)
 @("@nogc")
 @system @nogc unittest {
 
-    import std.experimental.allocator.mallocator: Mallocator;
+    import stdx.allocator.mallocator: Mallocator;
 
     {
         const ptr = Unique!(NoGcStruct, Mallocator)(5);
@@ -474,7 +474,7 @@ private template makeObject(Flag!"supportGC" supportGC, args...)
 
 @("release")
 @system unittest {
-    import std.experimental.allocator: dispose;
+    import stdx.allocator: dispose;
     import core.exception: AssertError;
 
     try {

--- a/source/automem/unique_array.d
+++ b/source/automem/unique_array.d
@@ -5,7 +5,7 @@ module automem.unique_array;
 
 import automem.traits: isAllocator;
 import automem.test_utils: TestUtils;
-import std.experimental.allocator: theAllocator;
+import stdx.allocator: theAllocator;
 
 version(unittest) {
     import unit_threaded;
@@ -130,7 +130,7 @@ struct UniqueArray(Type, Allocator = typeof(theAllocator)) if(isAllocator!Alloca
 
     @property void length(long size) {
 
-        import std.experimental.allocator: expandArray, shrinkArray;
+        import stdx.allocator: expandArray, shrinkArray;
 
         if(_objects is null) {
             makeObjects(size);
@@ -195,7 +195,7 @@ struct UniqueArray(Type, Allocator = typeof(theAllocator)) if(isAllocator!Alloca
        Reserves memory to prevent too many allocations
      */
     void reserve(in long size) {
-        import std.experimental.allocator: expandArray;
+        import stdx.allocator: expandArray;
 
         if(_objects is null) {
             const oldLength = length;
@@ -248,20 +248,20 @@ private:
         Allocator _allocator;
 
     void makeObjects(size_t size) {
-        import std.experimental.allocator: makeArray;
+        import stdx.allocator: makeArray;
         _objects = _allocator.makeArray!Type(size);
         setLength;
     }
 
     void makeObjects(size_t size, Type init) {
-        import std.experimental.allocator: makeArray;
+        import stdx.allocator: makeArray;
         _objects = _allocator.makeArray!Type(size, init);
         setLength;
 
     }
 
     void makeObjects(R)(R range) if(isInputRange!R) {
-        import std.experimental.allocator: makeArray;
+        import stdx.allocator: makeArray;
         _objects = _allocator.makeArray!Type(range);
         setLength;
     }
@@ -271,7 +271,7 @@ private:
     }
 
     void deleteObjects() {
-        import std.experimental.allocator: dispose;
+        import stdx.allocator: dispose;
         import std.traits: isPointer;
 
         static if(isPointer!Allocator)
@@ -305,7 +305,7 @@ private:
 
 @("default Mallocator")
 @system unittest {
-    import std.experimental.allocator.mallocator: Mallocator;
+    import stdx.allocator.mallocator: Mallocator;
     defaultTest!Mallocator;
 }
 
@@ -372,7 +372,7 @@ version(unittest) {
 @("@nogc")
 @system @nogc unittest {
 
-    import std.experimental.allocator.mallocator: Mallocator;
+    import stdx.allocator.mallocator: Mallocator;
 
     auto arr = UniqueArray!(NoGcStruct, Mallocator)(2);
     assert(arr.length == 2);
@@ -411,7 +411,7 @@ version(unittest) {
 
 @("init Mallocator")
 @system unittest {
-    import std.experimental.allocator.mallocator: Mallocator;
+    import stdx.allocator.mallocator: Mallocator;
     alias allocator = Mallocator.instance;
     auto arr = UniqueArray!(Struct, Mallocator)(2, Struct(7));
     arr[].shouldEqual([Struct(7), Struct(7)]);
@@ -427,7 +427,7 @@ version(unittest) {
 
 @("range Mallocator")
 @system unittest {
-    import std.experimental.allocator.mallocator: Mallocator;
+    import stdx.allocator.mallocator: Mallocator;
     auto arr = UniqueArray!(Struct, Mallocator)([Struct(1), Struct(2)]);
     arr[].shouldEqual([Struct(1), Struct(2)]);
 }
@@ -443,28 +443,28 @@ version(unittest) {
 
 @("issue 1 array")
 @system unittest {
-    import std.experimental.allocator.mallocator;
+    import stdx.allocator.mallocator;
     UniqueArray!(int, Mallocator) a;
     a ~= [0, 1];
 }
 
 @("issue 1 value")
 @system unittest {
-    import std.experimental.allocator.mallocator;
+    import stdx.allocator.mallocator;
     UniqueArray!(int, Mallocator) a;
     a ~= 7;
 }
 
 @("issue 1 UniqueArray")
 @system unittest {
-    import std.experimental.allocator.mallocator;
+    import stdx.allocator.mallocator;
     UniqueArray!(int, Mallocator) a;
     a ~= UniqueArray!(int, Mallocator)([1, 2, 3]);
 }
 
 @("dereference")
 unittest {
-    import std.experimental.allocator.mallocator;
+    import stdx.allocator.mallocator;
     UniqueArray!(int, Mallocator) a;
     a ~= [0, 1];
     (*a).shouldEqual([0, 1]);
@@ -530,7 +530,7 @@ unittest {
 
 @("dup Mallocator")
 @system unittest {
-    import std.experimental.allocator.mallocator: Mallocator;
+    import stdx.allocator.mallocator: Mallocator;
     auto a = UniqueArray!(int, Mallocator)([1, 2, 3, 4, 5]);
     auto b = a.dup;
     b[].shouldEqual([1, 2, 3, 4, 5]);


### PR DESCRIPTION
The `stdx-allocator` package provides a stable snapshot of the allocators module which is currently under work.

@atilaneves I'm guessing, fingers crossed :smiley:, this is the final step in unblocking this Phobos [PR](https://github.com/dlang/phobos/pull/6444)