### PR TITLE
Re-name consistent with phobos

### DIFF
--- a/source/automem/traits.d
+++ b/source/automem/traits.d
@@ -73,11 +73,11 @@ template isUnique(T) {
 /**
    The base type of a `Unique` pointer.
  */
-template UniqueType(T)
+template UniqueTarget(T)
 {
     import automem.unique: Unique;
     static assert(isUnique!T);
-    alias UniqueType = T.Type;
+    alias UniqueTarget = T.Type;
 }
 
 ///
@@ -91,7 +91,7 @@ template UniqueType(T)
     }
 
     auto u = Unique!Point(2, 3);
-    static assert(is(Point == UniqueType!(typeof(u))));
+    static assert(is(Point == UniqueTarget!(typeof(u))));
 }
 
 /**
@@ -123,11 +123,11 @@ template isRefCounted(T) {
 /**
    The base type of a `RefCounted` pointer.
  */
-template RefCountedType(T)
+template RefCountedTarget(T)
 {
     import automem.ref_counted: RefCounted;
     static assert(isRefCounted!T);
-    alias RefCountedType = T.Type;
+    alias RefCountedTarget = T.Type;
 }
 
 ///
@@ -141,5 +141,5 @@ template RefCountedType(T)
     }
 
     auto s = RefCounted!Point(2, 3);
-    static assert(is(Point == RefCountedType!(typeof(s))));
+    static assert(is(Point == RefCountedTarget!(typeof(s))));
 }

--- a/source/automem/traits.d
+++ b/source/automem/traits.d
@@ -71,30 +71,6 @@ template isUnique(T) {
 }
 
 /**
-   The base type of a `Unique` pointer.
- */
-template UniqueTarget(T)
-{
-    import automem.unique: Unique;
-    static assert(isUnique!T);
-    alias UniqueTarget = T.Type;
-}
-
-///
-@("Get the base type of a Unique type")
-@safe unittest {
-    import automem.unique: Unique;
-
-    static struct Point {
-        int x;
-        int y;
-    }
-
-    auto u = Unique!Point(2, 3);
-    static assert(is(Point == UniqueTarget!(typeof(u))));
-}
-
-/**
    Determines if a type is RefCounted.
  */
 template isRefCounted(T) {
@@ -120,19 +96,20 @@ template isRefCounted(T) {
     static assert(!isRefCounted!(typeof(p)));
 }
 
+
 /**
-   The base type of a `RefCounted` pointer.
+   The target of a `Unique` or `RefCounted` pointer.
  */
-template RefCountedTarget(T)
+template PointerTarget(T)
+    if (isUnique!T || isRefCounted!T)
 {
-    import automem.ref_counted: RefCounted;
-    static assert(isRefCounted!T);
-    alias RefCountedTarget = T.Type;
+    alias PointerTarget = T.Type;
 }
 
 ///
-@("Get the base type of a RefCounted type")
+@("Get the target of a Unique or RefCounter pointer")
 @safe unittest {
+    import automem.unique: Unique;
     import automem.ref_counted: RefCounted;
 
     static struct Point {
@@ -140,6 +117,9 @@ template RefCountedTarget(T)
         int y;
     }
 
+    auto u = Unique!Point(2, 3);
+    static assert(is(Point == PointerTarget!(typeof(u))));
+
     auto s = RefCounted!Point(2, 3);
-    static assert(is(Point == RefCountedTarget!(typeof(s))));
+    static assert(is(Point == PointerTarget!(typeof(s))));
 }


### PR DESCRIPTION
I realized that phobos' `std.traits` has a function called `PointerTarget` [1]. The functions `UniqueType` and `RefCountedType` I recently added should be named consistent with this, so `UniqueTarget` and `RefCountedTarget`.

[1] https://dlang.org/phobos/std_traits.html#PointerTarget