### PR TITLE
Fix #43 "Invariant violation in debug mode"

### DIFF
--- a/source/automem/vector.d
+++ b/source/automem/vector.d
@@ -148,7 +148,16 @@ struct Vector(E, Allocator = typeof(theAllocator)) if(isAllocator!Allocator) {
 
     /// Pops the last element off
     void popBack() {
+        assert(length);
         --_length;
+        debug
+        {
+            // restore invariant
+            static if(isElementMutable)
+                _elements[_length.toSizeT] = E.init;
+            else
+                mutableElements[_length.toSizeT] = E.init;
+        }
     }
 
     /// If the vector is empty

--- a/tests/ut/issues.d
+++ b/tests/ut/issues.d
@@ -73,3 +73,15 @@ else {
     auto rc = RefCounted!S();
     rc.front.shouldThrow!AssertError;
 }
+
+@("42")
+@system // unittest is system because Vector(T, M).opOpAssign is system
+unittest {
+    StringM str;
+    str ~= "a";
+    str.popBack;
+    str ~= "a"; // generates the error "Assigning to non default initialised non mutable member" in vector.d:297
+
+    assert(str.length == 1);
+    assert(str[0] == 'a');
+}


### PR DESCRIPTION
"Uninitialize" the storage element on `popBack`ing. Also `assert(length);` is useful on it own.
