### PR TITLE
Fix erroneous __traits(isSame) comparison

### DIFF
--- a/source/automem/utils.d
+++ b/source/automem/utils.d
@@ -14,8 +14,7 @@ void destruct(T)(T obj) if (is(T == interface)) {
 }
 
 void destruct(T)(ref T obj) if (is(T == struct)) {
-    static if (__traits(hasMember, T, "__xdtor") &&
-               __traits(isSame, T, __traits(parent, obj.__xdtor)))
+    static if (__traits(hasMember, T, "__xdtor"))
         obj.__xdtor;
 }
 


### PR DESCRIPTION
I'm fixing a compiler [bug](https://issues.dlang.org/show_bug.cgi?id=21889) and the following code causes a failed assertion on this lib.

The problem is that
```d
__traits(isSame, T, __traits(parent, obj.__xdtor))
```
 can end up as something like:

`__traits(isSame, const(Struct), Struct)`, which returns false, this is an problem when comparing a type with a symbol because symbols don't have qualifiers.

A natural fix could be just using `Unqual!T`. However, in this case the use of `isSame` is actually redundant, we already know `__xdtor` is member of `T` and `obj` is of type `T`.