### PR TITLE
Revert "Enable preview DIPs by default"

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -7,11 +7,6 @@ targetPath "bin"
 
 
 configuration "library" {
-    dflags "-preview=dip25" "-preview=dip1000" "-preview=dip1008"
-}
-
-configuration "nodips" {
-
 }
 
 


### PR DESCRIPTION
This reverts commit 7a9344f5bf03a9aaf5d323396940d7bbf121124c.