### PR TITLE
Fix incorrect `escape.element` test

### DIFF
--- a/tests/ut/vector.d
+++ b/tests/ut/vector.d
@@ -241,12 +241,16 @@ import test_allocator;
     int i = 1;
     int j = 2;
 
-    int* oops;
+    int** oops;
     scope vec = vector(&i, &j);
-    int* ok;
+    int** ok;
 
-    static assert(!__traits(compiles, oops = vec[0]));
-    ok = vec[0];
+    // Taking address of `ref` return not allowed in older dmd versions
+    static if (__VERSION__ >= 2101)
+    {
+        static assert(!__traits(compiles, oops = &vec[0]));
+        ok = &vec[0];
+    }
 }
 
 


### PR DESCRIPTION
Blocking https://github.com/dlang/dmd/pull/14871

There's no transitive scope, the `return scope` `opIndex()` method on a `scope` `struct Vector` protects pointers into the underlying `scope E[] _elements;`, but not the pointer values of the array elements themselves.