### PR TITLE
Remove deprecated -dip25 switch

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -18,7 +18,7 @@ configuration "unittest" {
     sourcePaths "tests"
     mainSourceFile "tests/ut_main.d"
 
-    dflags "-preview=dip25" "-preview=dip1000" "-preview=dip1008"
+    dflags "-preview=dip1000" "-preview=dip1008"
     versions "AutomemTesting"
 
     dependency "unit-threaded" version="*"
@@ -35,7 +35,7 @@ configuration "asan" {
     mainSourceFile "tests/ut_main.d"
 
     # -preview=dip1008 causes asan issues with malloc
-    dflags "-preview=dip25" "-preview=dip1000"
+    dflags "-preview=dip1000"
     dflags "-fsanitize=address" platform="ldc"
 
     // unit threaded light is necessary for the tests to actually run
@@ -53,7 +53,7 @@ configuration "utl" {
     importPaths "tests"
     sourcePaths "tests"
 
-    dflags "-preview=dip25" "-preview=dip1000" "-preview=dip1008"
+    dflags "-preview=dip1000" "-preview=dip1008"
 
     versions "AutomemTesting" "unitThreadedLight"
 


### PR DESCRIPTION
It's enabled by default / deprecated now, and also implied by dip1000