### PR TITLE
Fix deprecation about throwing of immutable exception

### DIFF
--- a/source/automem/vector.d
+++ b/source/automem/vector.d
@@ -537,12 +537,17 @@ static if (__VERSION__ >= 2082) { // version identifier D_Exceptions was added i
 
 
 static if (haveExceptions) {
-    private static immutable boundsException = new BoundsException("Out of bounds index");
+    private static BoundsException boundsException;
     private enum throwBoundsException = q{throw boundsException;};
     class BoundsException: Exception {
         import std.exception: basicExceptionCtors;
 
         mixin basicExceptionCtors;
+    }
+
+    static this()
+    {
+        boundsException = new BoundsException("Out of bounds index");
     }
 } else {
     private enum throwBoundsException = q{assert(0, "Out of bounds index");};


### PR DESCRIPTION
Starting from version 2.104.2, the front-end gives a deprecation message that you cannot throw object of const/immutable type. Here the immutable exception is made a mutable one and its initialization occurs in static this() ctor of the module.